### PR TITLE
Add a check that the UUID is in a valid format before trying to load prebid page

### DIFF
--- a/Sources/AdsSDKSwift/ZestyBannerView.swift
+++ b/Sources/AdsSDKSwift/ZestyBannerView.swift
@@ -28,6 +28,9 @@ public struct ZestyBannerView: View {
         self._imageURL = State(initialValue: defaultImageURL)
         self._ctaURL = State(initialValue: defaultCtaURL)
         self.uuidValid = UUID(uuidString: adUnitId) != nil
+        if !self.uuidValid {
+            print("[Warning] Ad Unit ID is not a valid UUID. Ad campaigns will not run until this is fixed.")
+        }
     }
     
     public var body: some View {

--- a/Sources/AdsSDKSwift/ZestyBannerView.swift
+++ b/Sources/AdsSDKSwift/ZestyBannerView.swift
@@ -14,6 +14,7 @@ public struct ZestyBannerView: View {
     let format: Formats
     private let defaultImageURL = "https://cdn.zesty.xyz/images/zesty/zesty-default-medium-rectangle.png"
     private let defaultCtaURL = "https://relay.zesty.xyz"
+    private var uuidValid: Bool = false
     
     @State private var imageURL: String = ""
     @State private var ctaURL: String = ""
@@ -26,11 +27,12 @@ public struct ZestyBannerView: View {
         self.format = format
         self._imageURL = State(initialValue: defaultImageURL)
         self._ctaURL = State(initialValue: defaultCtaURL)
+        self.uuidValid = UUID(uuidString: adUnitId) != nil
     }
     
     public var body: some View {
         VStack {
-            if !self.isLoading && self.campaignId != "None" {
+            if !self.uuidValid || (!self.isLoading && self.campaignId != "None") {
                 Link(destination: URL(string: ctaURL)!) {
                     KFImage.url(URL(string: imageURL))
                         .aspectRatio(contentMode: .fit)


### PR DESCRIPTION
Previously it would try to load the prebid page regardless, meaning if the UUID was in an invalid format it would just sit as an empty white box instead of falling back to the default banner